### PR TITLE
fix(src): enhance command handling

### DIFF
--- a/plugins/admins_commands/commands.lua
+++ b/plugins/admins_commands/commands.lua
@@ -124,11 +124,13 @@ commands:Register("rename", function(playerid, args, argsCount, silent, prefix)
         admin = GetPlayer(playerid)
     end
 
-    pl:CBasePlayerController().PlayerName = name
     if not admin:CBasePlayerController():IsValid() then return end
     ReplyToCommand(playerid, config:Fetch("admins.prefix"),
-        FetchTranslation("admins.rename.message"):gsub("{ADMIN_NAME}", admin:CBasePlayerController().PlayerName):gsub(
-            "{PLAYER_NAME}", pl:CBasePlayerController().PlayerName))
+    FetchTranslation("admins.rename.message")
+    :gsub("{ADMIN_NAME}", admin:CBasePlayerController().PlayerName)
+    :gsub("{PLAYER_NAME}", pl:CBasePlayerController().PlayerName)
+    :gsub("{NEW_NAME}", name))
+    pl:CBasePlayerController().PlayerName = name
 end)
 
 commands:Register("csay", function(playerid, args, argsCount, silent, prefix)

--- a/plugins/admins_commands/commands.lua
+++ b/plugins/admins_commands/commands.lua
@@ -16,7 +16,7 @@ commands:Register("slay", function(playerid, args, argsCount, silent, prefix)
             string.format(FetchTranslation("admins.slay.syntax"), prefix))
     end
 
-    local players = FindPlayersByTarget(args[1], false)
+    local players = FindPlayersByTarget(args[1], true)
     if #players == 0 then
         return ReplyToCommand(playerid, config:Fetch("admins.prefix"), FetchTranslation("admins.invalid_player"))
     end
@@ -55,7 +55,7 @@ commands:Register("slap", function(playerid, args, argsCount, silent, prefix)
             string.format(FetchTranslation("admins.slap.syntax"), prefix))
     end
 
-    local players = FindPlayersByTarget(args[1], false)
+    local players = FindPlayersByTarget(args[1], true)
     if #players == 0 then
         return ReplyToCommand(playerid, config:Fetch("admins.prefix"), "No players found.")
     end
@@ -107,7 +107,7 @@ commands:Register("rename", function(playerid, args, argsCount, silent, prefix)
             string.format(FetchTranslation("admins.rename.syntax"), prefix))
     end
 
-    local players = FindPlayersByTarget(args[1], false)
+    local players = FindPlayersByTarget(args[1], true)
     if #players == 0 then
         return ReplyToCommand(playerid, config:Fetch("admins.prefix"), "No players found.")
     end


### PR DESCRIPTION
I have enabled by default the option to use bots as targets, something that should have been implemented from the beginning. Most plugins in their standard version allow targeting commands to bots. This modification also prevents inexperienced users from coming in the future asking why they can't apply commands to bots.

I also improved the message when using the rename command to which I will also perform a PR in its respective repository.